### PR TITLE
Config

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,121 @@
+#include "config.h"
+
+#include "globals.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+constexpr std::size_t kConfigBufferSize = 1024;
+
+RuntimeConfig BuildDefaultRuntimeConfig() {
+    return RuntimeConfig{
+        kTelemetryPublishIntervalSec,
+        kHealthPublishIntervalSec,
+        kDefaultCurrentWarningThreshold,
+        kDefaultCurrentCriticalThreshold,
+        kDefaultPowerSpikeDelta,
+    };
+}
+
+bool ReadConfigFile(const char* config_path, char* buffer, std::size_t buffer_size) {
+    if (config_path == nullptr || buffer == nullptr || buffer_size < 2) {
+        return false;
+    }
+
+    std::FILE* config_file = std::fopen(config_path, "rb");
+    if (config_file == nullptr) {
+        return false;
+    }
+
+    const std::size_t bytes_read = std::fread(buffer, 1, buffer_size - 1, config_file);
+    buffer[bytes_read] = '\0';
+    std::fclose(config_file);
+    return bytes_read > 0;
+}
+
+const char* FindJsonValue(const char* json, const char* key) {
+    const char* key_position = std::strstr(json, key);
+    if (key_position == nullptr) {
+        return nullptr;
+    }
+
+    const char* colon = std::strchr(key_position, ':');
+    if (colon == nullptr) {
+        return nullptr;
+    }
+
+    ++colon;
+    while (*colon == ' ' || *colon == '\t' || *colon == '\n' || *colon == '\r') {
+        ++colon;
+    }
+
+    return colon;
+}
+
+bool TryParseUintField(const char* json, const char* key, std::uint32_t* value) {
+    const char* field = FindJsonValue(json, key);
+    if (field == nullptr) {
+        return false;
+    }
+
+    char* end = nullptr;
+    const unsigned long parsed = std::strtoul(field, &end, 10);
+    if (end == field) {
+        return false;
+    }
+
+    *value = static_cast<std::uint32_t>(parsed);
+    return true;
+}
+
+bool TryParseFloatField(const char* json, const char* key, float* value) {
+    const char* field = FindJsonValue(json, key);
+    if (field == nullptr) {
+        return false;
+    }
+
+    char* end = nullptr;
+    const float parsed = std::strtof(field, &end);
+    if (end == field) {
+        return false;
+    }
+
+    *value = parsed;
+    return true;
+}
+
+void ApplyConfigOverrides(const char* json, RuntimeConfig* config) {
+    if (json == nullptr || config == nullptr) {
+        return;
+    }
+
+    if (!TryParseUintField(json, "\"telemetry_interval_sec\"", &config->telemetry_interval_sec)) {
+        TryParseUintField(json, "\"publish_interval_sec\"", &config->telemetry_interval_sec);
+    }
+
+    TryParseUintField(json, "\"health_interval_sec\"", &config->health_interval_sec);
+    TryParseFloatField(json, "\"current_warning_threshold\"", &config->current_warning_threshold);
+    TryParseFloatField(json, "\"current_critical_threshold\"", &config->current_critical_threshold);
+    TryParseFloatField(json, "\"power_spike_delta\"", &config->power_spike_delta);
+}
+
+}  // namespace
+
+RuntimeConfig GetDefaultRuntimeConfig() {
+    return BuildDefaultRuntimeConfig();
+}
+
+bool InitRuntimeConfig(const char* config_path) {
+    g_runtime_config = BuildDefaultRuntimeConfig();
+
+    char config_buffer[kConfigBufferSize];
+    if (!ReadConfigFile(config_path, config_buffer, sizeof(config_buffer))) {
+        return false;
+    }
+
+    ApplyConfigOverrides(config_buffer, &g_runtime_config);
+    return true;
+}

--- a/src/config.h
+++ b/src/config.h
@@ -1,9 +1,9 @@
 #pragma once
 
 constexpr unsigned int kSensorSampleIntervalSec = 1;
-constexpr unsigned int kTelemetryPublishIntervalSec = 60;
+constexpr unsigned int kTelemetryPublishIntervalSec = 2;
 constexpr unsigned int kHealthPublishIntervalSec = 30;
-constexpr unsigned int kWifiRetryIntervalSec = 5;
+constexpr unsigned int kWifiRetryIntervalSec = 10;
 
 constexpr char kDefaultNodeId[] = "plug_01";
 constexpr char kDefaultNodeType[] = "plug";

--- a/src/config.h
+++ b/src/config.h
@@ -1,9 +1,20 @@
 #pragma once
 
+#include "types.h"
+
 constexpr unsigned int kSensorSampleIntervalSec = 1;
 constexpr unsigned int kTelemetryPublishIntervalSec = 2;
 constexpr unsigned int kHealthPublishIntervalSec = 30;
 constexpr unsigned int kWifiRetryIntervalSec = 10;
 
+constexpr float kDefaultCurrentWarningThreshold = 8.0F;
+constexpr float kDefaultCurrentCriticalThreshold = 10.0F;
+constexpr float kDefaultPowerSpikeDelta = 300.0F;
+
+constexpr char kFlashConfigPath[] = "/config.json";
+
 constexpr char kDefaultNodeId[] = "plug_01";
 constexpr char kDefaultNodeType[] = "plug";
+
+RuntimeConfig GetDefaultRuntimeConfig();
+bool InitRuntimeConfig(const char* config_path = kFlashConfigPath);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "buffer_manager.h"
 #include "command_manager.h"
+#include "config.h"
 #include "event_manager.h"
 #include "globals.h"
 #include "health_manager.h"
@@ -10,5 +11,6 @@
 #include "wifi_manager.h"
 
 int main() {
+    InitRuntimeConfig();
     return 0;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -40,8 +40,6 @@ struct SystemState {
     bool mqtt_connected;
     bool sensor_ok;
     std::uint32_t uptime_sec;
-    std::uint32_t telemetry_sequence_no;
-    std::uint32_t health_sequence_no;
     std::uint32_t buffered_count;
     char status[24];
 };

--- a/src/types.h
+++ b/src/types.h
@@ -8,8 +8,6 @@ struct SensorSample {
     float current;
     float power;
     float energy_wh;
-    float frequency;
-    float power_factor;
     bool valid;
 };
 


### PR DESCRIPTION
## Summary

this pr includes mainly the `InitRuntimeConfig()` function which will read the config file stored in the esp flash and then load them when rebooting the system. 

## Related Issue

#17 

## Scope

- [x] Firmware behavior
- [ ] MQTT contract or topic handling
- [ ] Sensor reading or event detection
- [ ] Buffering or reconnect flow
- [ ] Documentation only
- [ ] Other

## Changes

- 

## Testing

- [ ] Built firmware locally
- [ ] Tested on hardware
- [ ] Verified Wi-Fi reconnect behavior
- [ ] Verified MQTT publish/subscribe flow
- [ ] Not applicable

Describe what you tested, including board or node type when relevant.

## Risks

List behavior that could regress, especially around timing, buffering, commands, or connectivity.

## Deployment Notes

Include any config, topic, or rollout considerations for the E1 team.
