### PR TITLE
feat(wifi): add Wi-Fi task with auto reconnect and global state handling

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -18,3 +18,8 @@ constexpr char kDefaultNodeType[] = "plug";
 
 RuntimeConfig GetDefaultRuntimeConfig();
 bool InitRuntimeConfig(const char* config_path = kFlashConfigPath);
+
+constexpr int kWifiMaxRetryCount = 50;
+constexpr int kWifiShortDelayMs = 200;
+constexpr int kWifiRetryBackoffMs = 2000;
+constexpr int kWifiConnectedCheckMs = 5000;

--- a/include/wifi_config.h
+++ b/include/wifi_config.h
@@ -1,0 +1,4 @@
+#pragma once
+
+constexpr char WIFI_SSID[] = "Your_WiFi_Name";
+constexpr char WIFI_PASSWORD[] = "Your_WiFi_Password";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,9 @@ void setup() {
     Serial.begin(115200);
 
     // Initialize config
-    InitRuntimeConfig();
+    if (!InitRuntimeConfig()) {
+    Serial.println("Config load failed, using defaults");
+    }
 
     // Initialize Wi-Fi
     InitWifiManager();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,5 @@
+#include <Arduino.h>
+
 #include "buffer_manager.h"
 #include "command_manager.h"
 #include "config.h"
@@ -10,7 +12,23 @@
 #include "time_manager.h"
 #include "wifi_manager.h"
 
-int main() {
+void setup() {
+    Serial.begin(115200);
+
+    // Initialize config
     InitRuntimeConfig();
-    return 0;
+
+    // Initialize Wi-Fi
+    InitWifiManager();
+    RunWifiTask();
+
+    // (Later you will add more tasks here)
+    // RunMqttTask();
+    // RunSensorTask();
+    // etc.
+}
+
+void loop() {
+    // Keep loop alive (FreeRTOS tasks handle everything)
+    vTaskDelay(pdMS_TO_TICKS(1000));
 }

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -68,13 +68,17 @@ void InitWifiManager() {
 }
 
 void RunWifiTask() {
-    xTaskCreatePinnedToCore(
-        TaskWifi,
-        "TaskWifi",
-        8192,
-        nullptr,
-        1,
-        nullptr,
-        0
+    BaseType_t result = xTaskCreatePinnedToCore(
+    TaskWifi,
+    "TaskWifi",
+    8192,
+    nullptr,
+    1,
+    nullptr,
+    0
     );
+
+    if (result != pdPASS) {
+        Serial.println("Failed to create WiFi task");
+    }
 }

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -1,11 +1,13 @@
+#include <Arduino.h>
 #include "wifi_manager.h"
 #include <WiFi.h>
 #include "globals.h"
 #include "wifi_config.h"
+#include "config.h"
 
-void TaskWifi(void* pvParameters) {
+static void TaskWifi(void* pvParameters) {
     (void)pvParameters;
-    vTaskDelay(pdMS_TO_TICKS(200));
+    vTaskDelay(pdMS_TO_TICKS(kWifiShortDelayMs));
 
     WiFi.mode(WIFI_STA);
     WiFi.setAutoReconnect(true);
@@ -21,15 +23,15 @@ void TaskWifi(void* pvParameters) {
             g_system_state.wifi_connected = false;
 
             WiFi.disconnect(true);
-            vTaskDelay(pdMS_TO_TICKS(200));
+            vTaskDelay(pdMS_TO_TICKS(kWifiShortDelayMs));
 
             WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
 
             int tries = 0;
 
-            while (WiFi.status() != WL_CONNECTED)
+            while (WiFi.status() != WL_CONNECTED && tries++ < kWifiMaxRetryCount)
             {
-                vTaskDelay(pdMS_TO_TICKS(200));
+                vTaskDelay(pdMS_TO_TICKS(kWifiShortDelayMs));
                 Serial.print(".");
             }
 
@@ -50,13 +52,13 @@ void TaskWifi(void* pvParameters) {
                 Serial.println("WiFi connect failed, retrying...");
                 g_system_state.wifi_connected = false;
 
-                vTaskDelay(pdMS_TO_TICKS(2000));
+                vTaskDelay(pdMS_TO_TICKS(kWifiRetryBackoffMs));
             }
         }
         else
         {
             g_system_state.wifi_connected = true;
-            vTaskDelay(pdMS_TO_TICKS(5000));
+            vTaskDelay(pdMS_TO_TICKS(kWifiConnectedCheckMs));
         }
     }
 }

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -1,5 +1,77 @@
 #include "wifi_manager.h"
+#include <WiFi.h>
+#include "globals.h"
+#include "wifi_config.h"
 
-void InitWifiManager() {}
+void TaskWifi(void* pvParameters) {
+    vTaskDelay(pdMS_TO_TICKS(200));
 
-void RunWifiTask() {}
+    WiFi.mode(WIFI_STA);
+    WiFi.setAutoReconnect(true);
+    WiFi.persistent(false);
+
+    while (true)
+    {
+        if (WiFi.status() != WL_CONNECTED)
+        {
+            Serial.print("Connecting to WiFi: ");
+            Serial.println(WIFI_SSID);
+
+            g_system_state.wifi_connected = false;
+
+            WiFi.disconnect(true);
+            vTaskDelay(pdMS_TO_TICKS(200));
+
+            WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+
+            int tries = 0;
+
+            while (WiFi.status() != WL_CONNECTED && tries++ < 50)
+            {
+                vTaskDelay(pdMS_TO_TICKS(200));
+                Serial.print(".");
+            }
+
+            Serial.println();
+
+            if (WiFi.status() == WL_CONNECTED)
+            {
+                Serial.print("WiFi connected. IP: ");
+                Serial.println(WiFi.localIP());
+
+                Serial.print("RSSI: ");
+                Serial.println(WiFi.RSSI());
+
+                g_system_state.wifi_connected = true;
+            }
+            else
+            {
+                Serial.println("WiFi connect failed, retrying...");
+                g_system_state.wifi_connected = false;
+
+                vTaskDelay(pdMS_TO_TICKS(2000));
+            }
+        }
+        else
+        {
+            g_system_state.wifi_connected = true;
+            vTaskDelay(pdMS_TO_TICKS(5000));
+        }
+    }
+}
+
+void InitWifiManager() {
+    Serial.println("WiFi Manager Initialized");
+}
+
+void RunWifiTask() {
+    xTaskCreatePinnedToCore(
+        TaskWifi,
+        "TaskWifi",
+        8192,
+        nullptr,
+        1,
+        nullptr,
+        0
+    );
+}

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -4,6 +4,7 @@
 #include "wifi_config.h"
 
 void TaskWifi(void* pvParameters) {
+    (void)pvParameters;
     vTaskDelay(pdMS_TO_TICKS(200));
 
     WiFi.mode(WIFI_STA);
@@ -26,7 +27,7 @@ void TaskWifi(void* pvParameters) {
 
             int tries = 0;
 
-            while (WiFi.status() != WL_CONNECTED && tries++ < 50)
+            while (WiFi.status() != WL_CONNECTED)
             {
                 vTaskDelay(pdMS_TO_TICKS(200));
                 Serial.print(".");


### PR DESCRIPTION
## Summary

Implemented the Wi-Fi manager for the E1 edge node to establish and maintain network connectivity. This solves the problem of the node being unable to communicate with the backend system when Wi-Fi is unavailable.

## Related Issue

Related to #12

## Scope

- [x] Firmware behavior
- [ ] MQTT contract or topic handling
- [ ] Sensor reading or event detection
- [x] Buffering or reconnect flow
- [ ] Documentation only
- [ ] Other

## Changes

- Added Wi-Fi manager module
- Implemented FreeRTOS-based Wi-Fi task
- Added automatic Wi-Fi reconnection logic
- Implemented non-blocking retry mechanism
- Updated global system state (`wifi_connected`)
- Integrated Wi-Fi status with system architecture

## Testing

- [x] Built firmware locally
- [x] Tested on hardware
- [x] Verified Wi-Fi reconnect behavior
- [ ] Verified MQTT publish/subscribe flow
- [ ] Not applicable

Tested on ESP32 device:
- Verified successful connection on boot
- Simulated Wi-Fi disconnection and confirmed automatic reconnection
- Monitored serial logs for connection status and IP assignment

## Risks

- Frequent reconnect attempts may slightly impact timing if not tuned
- Incorrect Wi-Fi credentials will prevent connection
- Interaction with MQTT module depends on correct state updates

## Deployment Notes

- Requires valid Wi-Fi credentials configured in `wifi_config.h`
- No changes to MQTT topics or external interfaces
- Safe to deploy independently as it only affects connectivity layer