### PR TITLE
test(event-manager): validate event manager and event rule transitions with native unit tests

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,6 +28,7 @@ lib_deps =
 platform = native
 build_flags =
     -Iinclude
+    -Ilib/node_logic/src
 build_src_filter = -<*>
 test_build_src = no
 lib_deps =

--- a/test/test_event_manager/test_main.cpp
+++ b/test/test_event_manager/test_main.cpp
@@ -1,0 +1,318 @@
+#include <unity.h>
+#include <cstdio>
+#include <cstring>
+#include <cstdint>
+
+#include "types.h"
+#include "event_rules.h"
+
+// ─────────────────────────────────────────
+// Minimal globals — defined here for native
+// ─────────────────────────────────────────
+// struct SystemState {
+//     bool wifi_connected;
+//     bool mqtt_connected;
+//     bool sensor_ok;
+//     std::uint32_t uptime_sec;
+//     std::uint32_t buffered_count;
+//     char status[24];
+// };
+
+// struct RuntimeConfig {
+//     std::uint32_t telemetry_interval_sec;
+//     std::uint32_t health_interval_sec;
+//     float current_warning_threshold;
+//     float current_critical_threshold;
+//     float power_spike_delta;
+// };
+
+static SystemState g_system_state = {};
+static RuntimeConfig g_runtime_config = {};
+
+// ─────────────────────────────────────────
+// Stubs
+// ─────────────────────────────────────────
+static bool s_mqtt_publish_called = false;
+static bool s_enqueue_called      = false;
+
+static const char* GetNodeId()   { return "plug_01"; }
+static const char* GetNodeType() { return "plug"; }
+
+static void FormatTimestampISO8601(std::uint32_t, char* buf, std::size_t size) {
+    std::snprintf(buf, size, "2026-01-01T00:00:00Z");
+}
+
+// ─────────────────────────────────────────
+// Inline re-implementation of event_manager
+// logic — mirrors src/event_manager.cpp but
+// without Arduino/firmware dependencies
+// ─────────────────────────────────────────
+static constexpr std::uint32_t kDefaultEventCooldownSec    = 10;
+static constexpr float         kDefaultCurrentWarning      = 8.0F;
+static constexpr float         kDefaultPowerSpikeDelta     = 300.0F;
+static constexpr char          kEventTopicTemplate[]       = "energy/nodes/%s/events";
+
+enum class EventKind : std::size_t {
+    PowerSpike      = 0,
+    OverloadWarning = 1,
+    PowerDown       = 2,
+    Count,
+};
+
+static SensorSample  s_previous_sample                                          = {};
+static bool          s_has_previous_sample                                      = false;
+static bool          s_overload_active                                          = false;
+static std::uint32_t s_last_event_timestamps[static_cast<std::size_t>(EventKind::Count)] = {};
+
+static float GetWarningThreshold() {
+    return g_runtime_config.current_warning_threshold > 0.0F
+               ? g_runtime_config.current_warning_threshold
+               : kDefaultCurrentWarning;
+}
+
+static float GetSpikeDelta() {
+    return g_runtime_config.power_spike_delta > 0.0F
+               ? g_runtime_config.power_spike_delta
+               : kDefaultPowerSpikeDelta;
+}
+
+static bool IsWithinCooldown(EventKind kind, std::uint32_t ts) {
+    const std::size_t   idx  = static_cast<std::size_t>(kind);
+    const std::uint32_t last = s_last_event_timestamps[idx];
+    if (last == 0)        return false;
+    if (ts <= last)       return true;
+    return (ts - last) < kDefaultEventCooldownSec;
+}
+
+static void MarkEmitted(EventKind kind, std::uint32_t ts) {
+    s_last_event_timestamps[static_cast<std::size_t>(kind)] = ts;
+}
+
+// struct EventMessage {
+//     char         event_type[32];
+//     char         severity[16];
+//     char         message[128];
+//     std::uint32_t timestamp;
+//     bool         buffered;
+// };
+
+static void BuildEvent(EventMessage* e,
+                       const char*   event_type,
+                       const char*   severity,
+                       const char*   message,
+                       std::uint32_t ts,
+                       bool          buffered) {
+    std::memset(e, 0, sizeof(EventMessage));
+    std::snprintf(e->event_type, sizeof(e->event_type), "%s", event_type);
+    std::snprintf(e->severity,   sizeof(e->severity),   "%s", severity);
+    std::snprintf(e->message,    sizeof(e->message),    "%s", message);
+    e->timestamp = ts;
+    e->buffered  = buffered;
+}
+
+static bool TryPublish(const EventMessage&) {
+    if (!g_system_state.wifi_connected || !g_system_state.mqtt_connected) {
+        return false;
+    }
+    s_mqtt_publish_called = true;
+    return true;
+}
+
+static void BufferEvent(const EventMessage&) {
+    s_enqueue_called = true;
+}
+
+static void EmitEvent(EventKind     kind,
+                      const char*   event_type,
+                      const char*   severity,
+                      const char*   message,
+                      std::uint32_t ts) {
+    if (IsWithinCooldown(kind, ts)) return;
+
+    EventMessage event;
+    BuildEvent(&event, event_type, severity, message, ts, false);
+    if (!TryPublish(event)) {
+        event.buffered = true;
+        BufferEvent(event);
+    }
+    MarkEmitted(kind, ts);
+}
+
+static void InitEventManager() {
+    std::memset(s_last_event_timestamps, 0, sizeof(s_last_event_timestamps));
+    s_previous_sample     = SensorSample{};
+    s_has_previous_sample = false;
+    s_overload_active     = false;
+}
+
+static SensorSample s_latest_sample = {};
+
+static void RunEventTask() {
+    const SensorSample current = s_latest_sample;
+    if (!current.valid) return;
+
+    if (!s_has_previous_sample) {
+        s_previous_sample     = current;
+        s_has_previous_sample = true;
+        s_overload_active     = current.current > GetWarningThreshold();
+        return;
+    }
+
+    if (current.timestamp == s_previous_sample.timestamp) return;
+
+    const EventEvaluation ev = EvaluateEventTransitions(
+        s_previous_sample, current,
+        GetWarningThreshold(), GetSpikeDelta(),
+        s_overload_active);
+
+    if (ev.emit_power_spike) {
+        EmitEvent(EventKind::PowerSpike, "power_spike", "high",
+                  "Power increased above configured spike delta", current.timestamp);
+    }
+    if (ev.emit_overload_warning) {
+        EmitEvent(EventKind::OverloadWarning, "overload_warning", "high",
+                  "Current exceeded warning threshold", current.timestamp);
+    }
+    s_overload_active = ev.overload_active;
+
+    if (ev.emit_power_down) {
+        EmitEvent(EventKind::PowerDown, "power_down", "medium",
+                  "Load dropped to zero from active state", current.timestamp);
+    }
+
+    s_previous_sample = current;
+}
+
+// ─────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────
+static SensorSample BuildSample(std::uint32_t ts, float current, float power, bool valid = true) {
+    SensorSample s = {};
+    s.timestamp = ts;
+    s.current   = current;
+    s.power     = power;
+    s.valid     = valid;
+    return s;
+}
+
+static void SetConnected() {
+    g_system_state.wifi_connected = true;
+    g_system_state.mqtt_connected = true;
+}
+
+static void ResetState() {
+    g_system_state  = SystemState{};
+    g_runtime_config = RuntimeConfig{};
+    s_latest_sample  = SensorSample{};
+    s_mqtt_publish_called = false;
+    s_enqueue_called      = false;
+    InitEventManager();
+}
+
+// ─────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────
+void test_first_valid_sample_does_not_emit_event() {
+    ResetState();
+    SetConnected();
+    s_latest_sample = BuildSample(1, 9.0F, 500.0F);
+    RunEventTask();
+    TEST_ASSERT_FALSE(s_mqtt_publish_called);
+}
+
+void test_invalid_sample_does_not_emit_event() {
+    ResetState();
+    SetConnected();
+    s_latest_sample = BuildSample(1, 0.0F, 0.0F, false);
+    RunEventTask();
+    TEST_ASSERT_FALSE(s_mqtt_publish_called);
+}
+
+void test_power_spike_emits_event() {
+    ResetState();
+    SetConnected();
+    s_latest_sample = BuildSample(1, 1.0F, 100.0F);
+    RunEventTask();
+    s_mqtt_publish_called = false;
+    s_latest_sample = BuildSample(2, 1.2F, 450.0F);
+    RunEventTask();
+    TEST_ASSERT_TRUE(s_mqtt_publish_called);
+}
+
+void test_overload_warning_emits_event() {
+    ResetState();
+    SetConnected();
+    s_latest_sample = BuildSample(1, 7.0F, 200.0F);
+    RunEventTask();
+    s_mqtt_publish_called = false;
+    s_latest_sample = BuildSample(2, 9.0F, 220.0F);
+    RunEventTask();
+    TEST_ASSERT_TRUE(s_mqtt_publish_called);
+}
+
+void test_power_down_emits_event() {
+    ResetState();
+    SetConnected();
+    s_latest_sample = BuildSample(1, 1.4F, 320.0F);
+    RunEventTask();
+    s_mqtt_publish_called = false;
+    s_latest_sample = BuildSample(2, 0.0F, 0.0F);
+    RunEventTask();
+    TEST_ASSERT_TRUE(s_mqtt_publish_called);
+}
+
+void test_same_timestamp_does_not_reprocess() {
+    ResetState();
+    SetConnected();
+    s_latest_sample = BuildSample(1, 1.0F, 100.0F);
+    RunEventTask();
+    s_latest_sample = BuildSample(2, 1.2F, 450.0F);
+    RunEventTask();
+    s_mqtt_publish_called = false;
+    RunEventTask();  // same timestamp — should skip
+    TEST_ASSERT_FALSE(s_mqtt_publish_called);
+}
+
+void test_event_buffered_when_mqtt_disconnected() {
+    ResetState();
+    g_system_state.wifi_connected = false;
+    g_system_state.mqtt_connected = false;
+    s_latest_sample = BuildSample(1, 1.0F, 100.0F);
+    RunEventTask();
+    s_latest_sample = BuildSample(2, 1.2F, 450.0F);
+    RunEventTask();
+    TEST_ASSERT_FALSE(s_mqtt_publish_called);
+    TEST_ASSERT_TRUE(s_enqueue_called);
+}
+
+void test_cooldown_suppresses_duplicate_event() {
+    ResetState();
+    SetConnected();
+    s_latest_sample = BuildSample(1, 1.0F, 100.0F);
+    RunEventTask();
+    s_latest_sample = BuildSample(2, 1.2F, 450.0F);
+    RunEventTask();
+    s_mqtt_publish_called = false;
+    s_latest_sample = BuildSample(3, 1.2F, 800.0F);  // within cooldown
+    RunEventTask();
+    TEST_ASSERT_FALSE(s_mqtt_publish_called);
+}
+
+// ─────────────────────────────────────────
+// Unity required
+// ─────────────────────────────────────────
+void setUp()    { ResetState(); }
+void tearDown() {}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_first_valid_sample_does_not_emit_event);
+    RUN_TEST(test_invalid_sample_does_not_emit_event);
+    RUN_TEST(test_power_spike_emits_event);
+    RUN_TEST(test_overload_warning_emits_event);
+    RUN_TEST(test_power_down_emits_event);
+    RUN_TEST(test_same_timestamp_does_not_reprocess);
+    RUN_TEST(test_event_buffered_when_mqtt_disconnected);
+    RUN_TEST(test_cooldown_suppresses_duplicate_event);
+    return UNITY_END();
+}

--- a/test/test_event_rules/test_main.cpp
+++ b/test/test_event_rules/test_main.cpp
@@ -56,7 +56,60 @@ void test_invalid_samples_do_not_emit_events() {
     TEST_ASSERT_FALSE(evaluation.overload_active);
 }
 
+void test_power_spike_not_triggered_on_small_delta() {
+    const SensorSample previous = BuildSample(1, 1.0F, 100.0F);
+    const SensorSample current = BuildSample(2, 1.1F, 150.0F);
+
+    const EventEvaluation evaluation = EvaluateEventTransitions(previous, current, 8.0F, 300.0F, false);
+    TEST_ASSERT_FALSE(evaluation.emit_power_spike);
+}
+
+void test_overload_not_triggered_below_threshold() {
+    const SensorSample previous = BuildSample(1, 6.0F, 200.0F);
+    const SensorSample current = BuildSample(2, 7.9F, 210.0F);
+
+    const EventEvaluation evaluation = EvaluateEventTransitions(previous, current, 8.0F, 300.0F, false);
+    TEST_ASSERT_FALSE(evaluation.emit_overload_warning);
+    TEST_ASSERT_FALSE(evaluation.overload_active);
+}
+
+void test_power_down_not_triggered_when_load_stays_active() {
+    const SensorSample previous = BuildSample(1, 1.4F, 320.0F);
+    const SensorSample current = BuildSample(2, 1.3F, 310.0F);
+
+    const EventEvaluation evaluation = EvaluateEventTransitions(previous, current, 8.0F, 300.0F, false);
+    TEST_ASSERT_FALSE(evaluation.emit_power_down);
+}
+
+void test_power_down_not_triggered_when_load_was_already_zero() {
+    const SensorSample previous = BuildSample(1, 0.0F, 0.0F);
+    const SensorSample current = BuildSample(2, 0.0F, 0.0F);
+
+    const EventEvaluation evaluation = EvaluateEventTransitions(previous, current, 8.0F, 300.0F, false);
+    TEST_ASSERT_FALSE(evaluation.emit_power_down);
+}
+
+void test_spike_and_overload_can_trigger_simultaneously() {
+    const SensorSample previous = BuildSample(1, 7.5F, 100.0F);
+    const SensorSample current = BuildSample(2, 9.0F, 450.0F);
+
+    const EventEvaluation evaluation = EvaluateEventTransitions(previous, current, 8.0F, 300.0F, false);
+    TEST_ASSERT_TRUE(evaluation.emit_power_spike);
+    TEST_ASSERT_TRUE(evaluation.emit_overload_warning);
+}
+
+void test_power_spike_not_triggered_on_power_decrease() {
+    const SensorSample previous = BuildSample(1, 1.0F, 500.0F);
+    const SensorSample current = BuildSample(2, 0.5F, 100.0F);
+
+    const EventEvaluation evaluation = EvaluateEventTransitions(previous, current, 8.0F, 300.0F, false);
+    TEST_ASSERT_FALSE(evaluation.emit_power_spike);
+}
+
 }  // namespace
+
+void setUp() {}
+void tearDown() {}
 
 int main() {
     UNITY_BEGIN();
@@ -64,5 +117,11 @@ int main() {
     RUN_TEST(test_overload_warning_only_on_rising_edge);
     RUN_TEST(test_power_down_detected_from_active_to_zero);
     RUN_TEST(test_invalid_samples_do_not_emit_events);
+    RUN_TEST(test_power_spike_not_triggered_on_small_delta);
+    RUN_TEST(test_overload_not_triggered_below_threshold);
+    RUN_TEST(test_power_down_not_triggered_when_load_stays_active);
+    RUN_TEST(test_power_down_not_triggered_when_load_was_already_zero);
+    RUN_TEST(test_spike_and_overload_can_trigger_simultaneously);
+    RUN_TEST(test_power_spike_not_triggered_on_power_decrease);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
Adds native unit tests for the event manager and event rule logic. The event rules were previously untested and the event manager had no automated coverage at all. This PR verifies that event detection, cooldown suppression, buffering fallback, and edge case handling all behave correctly without requiring hardware or a live broker.

## Related Issue
No issue created yet for this task.

## Scope
- [ ] Firmware behavior
- [ ] MQTT contract or topic handling
- [x] Sensor reading or event detection
- [x] Buffering or reconnect flow
- [ ] Documentation only
- [ ] Other



## Changes
- `test/test_event_rules/test_main.cpp` — added `setUp`/`tearDown` required by Unity, expanded coverage with 6 additional test cases covering negative cases, boundary conditions, and simultaneous event triggers
- `test/test_event_manager/test_main.cpp` — new test file with 8 tests covering event emission, cooldown suppression, duplicate timestamp skipping, first-sample baseline behaviour, invalid sample handling, and buffer fallback when MQTT is disconnected
- `platformio.ini` — added `-Ilib/node_logic/src` to native build flags so `event_rules.h` resolves correctly in the native environment

## Testing
- [x] Built firmware locally
- [ ] Tested on hardware
- [ ] Verified Wi-Fi reconnect behavior
- [ ] Verified MQTT publish/subscribe flow
- [x] Not applicable (hardware not required for native tests)

All 18 native unit tests pass:
- 10 tests in `test_event_rules` — all passed
- 8 tests in `test_event_manager` — all passed

Run with: pio test -e native

## Risks
- `test_event_manager` re-implements event manager logic inline rather than compiling `src/event_manager.cpp` directly. This is intentional — `event_manager.cpp` depends on Arduino headers that are unavailable in the native environment. If the real `event_manager.cpp` logic changes, the test file must be updated to match.

## Deployment Notes
- No firmware behaviour changed. Tests only.
- `pio test -e native` can be run on any developer machine without hardware.